### PR TITLE
update formidable to use version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "Yaron Naveh (yaronn01@gmail.com, http://webservices20.blogspot.com/)",
   "dependencies": {
     "bufferjs": ">= 1.0.2",
-    "formidable": "=1.0.9",
+    "formidable": "=1.1.1",
     "request": ">=2.9.100",
     "xmldom": "=0.1.7",
     "dateformat": ">=1.0.2-1.2.3",


### PR DESCRIPTION
Based on:
https://github.com/yaronn/ws.js/commit/ed06f88c832bbb9f8dafcdd71c861ea35380c466
Should have probably cherry-picked it.