### PR TITLE
Fix issue with node 10 and options.ca issue

### DIFF
--- a/lib/handlers/client/http.js
+++ b/lib/handlers/client/http.js
@@ -9,7 +9,7 @@ function HttpClientHandler(options) {
 }
 
 HttpClientHandler.prototype.send = function(ctx, callback) {
-  var options = JSON.parse(JSON.stringify(this.options));
+  var options = this.options;
   options.url = ctx.url;
   options.body = ctx.request;
   options.headers = {


### PR DESCRIPTION
The json.stringify json.parse object clone methods changes the type of
the ca option in a way that the http module of node 10 does not support.
Since this is just a ugly fork and only used in one single place,
(ikano integration), simply remove the clone. This will of course make
this code modify the passed in options object but I can live with that.

AB-1351